### PR TITLE
chore: add pulse verification workflow

### DIFF
--- a/.github/workflows/pulse-verify.yml
+++ b/.github/workflows/pulse-verify.yml
@@ -1,0 +1,98 @@
+name: Pulse Verify
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      prod_flags: 'false'
+      outputs: json_only
+      include_annotations: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAGES_TOKEN }}
+
+      - name: Check Pages build status
+        run: |
+          status=$(curl -fsS -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/pages/builds | jq -r '.[0].status')
+          echo "Pages build status: $status"
+          if [ "$status" = "failed" ]; then
+            echo "Latest Pages build failed"
+            exit 1
+          fi
+
+      - name: Set Pulse URLs
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          echo "DATE=$DATE" >> $GITHUB_ENV
+          echo "URL_LATEST=https://twocats-network.github.io/twocats-network-status/pulse/latest.json" >> $GITHUB_ENV
+          echo "URL_RUN=https://twocats-network.github.io/twocats-network-status/pulse/$DATE/run.json" >> $GITHUB_ENV
+
+      - name: Curl Pulse URLs
+        run: |
+          set +e
+          LATEST_OK=false
+          RUN_OK=false
+          for url_var in URL_LATEST URL_RUN; do
+            url=${!url_var}
+            echo "Fetching $url"
+            success=false
+            for i in {1..10}; do
+              http=$(curl -L -sS -o resp.txt -w "%{http_code}" "$url" || true)
+              body=$(head -c 200 resp.txt | tr '\n' ' ')
+              echo "Attempt $i: HTTP $http - $body"
+              if [ "$http" = "200" ]; then
+                success=true
+                break
+              fi
+              sleep 10
+            done
+            if [ "$url_var" = "URL_LATEST" ]; then
+              LATEST_OK=$success
+            else
+              RUN_OK=$success
+            fi
+          done
+          echo "LATEST_OK=$LATEST_OK" >> $GITHUB_ENV
+          echo "RUN_OK=$RUN_OK" >> $GITHUB_ENV
+
+      - name: Retrigger Pages
+        if: env.LATEST_OK != 'true' || env.RUN_OK != 'true'
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout gh-pages
+          now=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          jq --arg now "$now" '.last_updated=$now' pulse/latest.json > pulse/latest.json.tmp && mv pulse/latest.json.tmp pulse/latest.json
+          git commit -am "chore: retrigger pages" || echo "No changes to commit"
+          git push origin gh-pages
+
+      - name: Curl after retrigger
+        if: env.LATEST_OK != 'true' || env.RUN_OK != 'true'
+        run: |
+          set -e
+          for url_var in URL_LATEST URL_RUN; do
+            url=${!url_var}
+            echo "Fetching $url"
+            success=false
+            for i in {1..3}; do
+              http=$(curl -L -sS -o resp.txt -w "%{http_code}" "$url" || true)
+              body=$(head -c 200 resp.txt | tr '\n' ' ')
+              echo "Attempt $i: HTTP $http - $body"
+              if [ "$http" = "200" ]; then
+                success=true
+                break
+              fi
+              sleep 10
+            done
+            if [ "$success" != "true" ]; then
+              echo "$url still not reachable"
+              exit 1
+            fi
+          done
+


### PR DESCRIPTION
## Summary
- add workflow to verify GitHub Pages pulse JSONs and retry builds if missing

## Testing
- `npm test` *(fails: Could not read package.json)*

[[GENESIS_STATUS component="Pulse" task="verify-pages"]]

------
https://chatgpt.com/codex/tasks/task_e_689a17a7ba148320965c8f0b4da9078e