### PR TITLE
chore: add people team-update event

### DIFF
--- a/pulse/2025-08-11/run.json
+++ b/pulse/2025-08-11/run.json
@@ -100,4 +100,36 @@
     },
     "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-intros\"]]"
   }
+  ,{
+    "component": "People",
+    "task": "team-update",
+    "status": "info",
+    "owner": "TWOCATS-network",
+    "repo": "twocats-network-status",
+    "workflow": "manual",
+    "run_id": "0",
+    "commit_sha": "",
+    "created_at": "2025-08-11T17:44:11Z",
+    "annotations": {
+      "note": "Full team status update and current blockers prior to Pulse handoff from Dev-007 to Dev-005.",
+      "team": [
+        { "id": "DEV-003", "role": "Protocol", "focus": "B1 Fate ERC-4626, C1 FLD Add-LP", "north_star": "Green on demand; red means actionable", "threads": ["CI Strike Team"] },
+        { "id": "DEV-004", "role": "Strategies", "focus": "Vault specs & APR/TVL docs", "north_star": "Every vault ships with risk notes and green tests", "threads": ["Genesis Mission Control"] },
+        { "id": "DEV-005", "role": "PulseBridge", "focus": "Pulse feed ops & product tiles", "north_star": "Public machine-readable telemetry, zero ambiguity", "threads": ["Genesis Mission Control"] },
+        { "id": "DEV-006", "role": "CI & Guardrails", "focus": "Compiler pin/mirror/cache, branch policy enforcement", "north_star": "CI stability & enforced guardrails", "threads": ["CI Strike Team"] },
+        { "id": "DEV-007", "role": "Cross-chain Yield & RWA / Pulse setup", "focus": "Initial Pulse bootstrapping & handoff", "north_star": "Fully operational Pulse before handoff", "threads": ["Genesis Mission Control"] }
+      ],
+      "unblockers": [
+        "Fix PR #18 constructor arg mismatch & relax gas bound to ≤130k",
+        "Merge PR #21 (ABI/Gas pipeline) after #18 fix",
+        "Merge Codex tasks for pulse-append.yml + team-intros event",
+        "Create GH_PAGES_TOKEN_PULSE secret + env vars for Pulse repo"
+      ],
+      "urls": [
+        "https://twocats-network.github.io/twocats-network-status/pulse/latest.json",
+        "https://twocats-network.github.io/twocats-network-status/pulse/2025-08-11/run.json"
+      ]
+    },
+    "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-update\"]]"
+  }
 ]

--- a/pulse/latest.json
+++ b/pulse/latest.json
@@ -1,6 +1,6 @@
 {
   "date": "2025-08-11",
   "path": "pulse/2025-08-11/run.json",
-  "last_updated": "2025-08-11T17:36:06Z",
-  "last_event": "People/team-intros"
+  "last_updated": "2025-08-11T17:44:11Z",
+  "last_event": "People/team-update"
 }


### PR DESCRIPTION
## Summary
- append People/team-update event with team snapshot and blockers
- point latest.json to People/team-update

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://twocats-network.github.io/twocats-network-status/pulse/latest.json` *(fails: 403 CONNECT tunnel failed)*
- `curl -s -o /tmp/run.json -w "%{http_code}\n" https://twocats-network.github.io/twocats-network-status/pulse/2025-08-11/run.json` *(fails: 000)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b6a400883208c6c3b62969d6433