### PR TITLE
Limit hedge consume workflow triggers to manual and dispatch events

### DIFF
--- a/.github/workflows/hedge-consume.yml
+++ b/.github/workflows/hedge-consume.yml
@@ -3,26 +3,19 @@ name: Hedge Consumer
 on:
   workflow_dispatch:
     inputs:
-      lane:
-        description: "A or B"
-        required: true
-        default: "A"
-      results_url:
-        description: "Public JSON URL (optional)"
-        required: false
-      inline_json:
-        description: "Paste results JSON (optional)"
-        required: false
-      env_target:
-        description: "dev|staging|prod"
-        required: true
-        default: "staging"
+      lane:        { description: "A or B", required: true, default: "A" }
+      results_url: { description: "Public JSON URL (optional)", required: false }
+      inline_json: { description: "Paste results JSON (optional)", required: false }
+      env_target:  { description: "dev|staging|prod", required: true, default: "staging" }
+  repository_dispatch:
+    types: [hedge-results]
 
 permissions:
   contents: write
 
 jobs:
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -36,15 +29,24 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve payload
+        id: payload
+        shell: bash
         run: |
-          if [ -n "${{ github.event.inputs.results_url }}" ]; then
-            curl -sSL "${{ github.event.inputs.results_url }}" -o results.json
-          elif [ -n "${{ github.event.inputs.inline_json }}" ]; then
-            echo '${{ github.event.inputs.inline_json }}' > results.json
-          else
-            echo "results_url or inline_json required" >&2
-            exit 1
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo '${{ toJson(github.event.client_payload) }}' > ev.json
+            curl -fsSL "$(jq -r '.results_url' ev.json)" -o results.json
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [ -n "${{ inputs.results_url }}" ]; then
+              curl -fsSL "${{ inputs.results_url }}" -o results.json
+            elif [ -n "${{ inputs.inline_json }}" ]; then
+              echo '${{ inputs.inline_json }}' > results.json
+            else
+              echo "Manual run without inputs — noop"; exit 0
+            fi
           fi
+          jq -e '.lane and .timestamp and .risk_state and .metrics and .scenarios' results.json >/dev/null
+          echo "lane=$(jq -r '.lane' results.json)" >> $GITHUB_OUTPUT
 
       - name: Validate results
         run: |
@@ -56,14 +58,14 @@ jobs:
 
       - name: Publish lane data
         run: |
-          lane=${{ github.event.inputs.lane }}
+          lane=${{ steps.payload.outputs.lane }}
           mkdir -p pages/pulse/data/hedge/lane${lane}
           cp pulse.json pages/pulse/data/hedge/lane${lane}/latest.json
 
       - name: Update environment annotations
         run: |
-          lane=${{ github.event.inputs.lane }}
-          env=${{ github.event.inputs.env_target }}
+          lane=${{ steps.payload.outputs.lane }}
+          env=${{ inputs.env_target }}
           file="pages/pulse/${env}/latest.json"
           if [ ! -f "$file" ]; then
             mkdir -p "$(dirname "$file")"
@@ -85,6 +87,6 @@ JSON
           cd pages
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add pulse/data/hedge/lane${{ github.event.inputs.lane }}/latest.json pulse/${{ github.event.inputs.env_target }}/latest.json
-          git commit -m "Hedge lane${{ github.event.inputs.lane }} update" || echo "No changes to commit"
+          git add pulse/data/hedge/lane${{ steps.payload.outputs.lane }}/latest.json pulse/${{ inputs.env_target }}/latest.json
+          git commit -m "Hedge lane${{ steps.payload.outputs.lane }} update" || echo "No changes to commit"
           git push origin gh-pages


### PR DESCRIPTION
## Summary
- restrict hedge-consume workflow to `workflow_dispatch` and `repository_dispatch` triggers
- add guard so publish job runs only for those events
- resolve payload for dispatch and manual runs with noop when no inputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a548acd9c83208f004a19be87aaaa