### PR TITLE
Add Pulse tile specs and publisher workflow

### DIFF
--- a/.github/workflows/pulse-tiles-publish.yml
+++ b/.github/workflows/pulse-tiles-publish.yml
@@ -1,0 +1,36 @@
+name: Pulse — Tiles Publish
+on:
+  workflow_dispatch:
+    inputs:
+      env_target: { description: "dev|staging|prod", required: true, default: "staging" }
+permissions:
+  contents: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: gh-pages, fetch-depth: 0, path: pages }
+      - name: Sync tile specs to Pages
+        run: |
+          set -euo pipefail
+          mkdir -p pages/pulse/tiles pages/pulse/tiles/hedge
+          cp -a pulse/tiles/*.json pages/pulse/tiles/ || true
+          cp -a pulse/tiles/hedge/*.json pages/pulse/tiles/hedge/ || true
+          # ensure env latest pointer exists
+          ENV="${{ inputs.env_target }}"; DATE=$(date -u +%F)
+          mkdir -p "pages/pulse/$ENV/$DATE"
+          ENV_LATEST="pages/pulse/$ENV/latest.json"
+          if [[ ! -f "$ENV_LATEST" ]]; then
+            printf '{"date":"%s","path":"pulse/%s/%s/run.json","last_updated":null,"last_event":null,"annotations":{}}\n' "$DATE" "$ENV" "$DATE" > "$ENV_LATEST"
+          fi
+          # attach tiles index pointer for convenience
+          jq --arg p "pulse/tiles/index.json" '.annotations.tiles_index = $p | .last_updated = (now | todate)' "$ENV_LATEST" > t && mv t "$ENV_LATEST"
+      - name: Commit & push
+        run: |
+          cd pages
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pulse
+          git commit -m "Publish tiles & index" || true
+          git push origin gh-pages

--- a/docs/pulse/TILES.md
+++ b/docs/pulse/TILES.md
@@ -1,0 +1,29 @@
+# Pulse Tiles
+
+The Pulse repository publishes machine-readable tile specifications for dashboards and agents.
+
+## Available tiles
+
+- **Feed Heartbeat**  
+  Source: `pulse/staging/latest.json` (defaults to `env_default` unless overridden)  
+  Fields: `last_updated`, `last_event.component`, `last_event.task`, `last_event.status`
+- **Hedge — Lane A**  
+  Source: `pulse/data/hedge/laneA/latest.json`  
+  Fields: `readiness`, `metrics.max_notional`, `metrics.var_24h_bps`, `metrics.slippage_at_size_bps`, `timestamp`
+- **Hedge — Lane B**  
+  Source: `pulse/data/hedge/laneB/latest.json`  
+  Fields: `readiness`, `metrics.max_notional`, `metrics.var_24h_bps`, `metrics.slippage_at_size_bps`, `timestamp`
+- **PR Activity (last 10)**  
+  Source: `pulse/api/events/latest.json`  
+  Filter: `component=PR`, limit 10  
+  Fields: `timestamp`, `owner`, `status`, `summary`, `pr_number`, `pr_url`
+
+## Tile index
+
+Fetch the index to discover all tiles:
+
+```
+GET https://twocats-network.github.io/twocats-network-status/pulse/tiles/index.json
+```
+
+Heartbeat tiles use `env_default=staging` unless explicitly overridden.

--- a/pulse/tiles/heartbeat.tile.json
+++ b/pulse/tiles/heartbeat.tile.json
@@ -1,0 +1,7 @@
+{
+  "title": "Feed Heartbeat",
+  "env": "staging",
+  "source": "pulse/staging/latest.json",
+  "fields": ["last_updated","last_event.component","last_event.task","last_event.status"],
+  "notes": "Auto-updates when any event is appended"
+}

--- a/pulse/tiles/hedge/laneA.tile.json
+++ b/pulse/tiles/hedge/laneA.tile.json
@@ -1,15 +1,5 @@
 {
-  "version": "1.0",
-  "lane": "A",
-  "readiness": "unknown",
-  "metrics": {
-    "max_notional": null,
-    "var_24h_bps": null,
-    "slippage_at_size_bps": null
-  },
-  "last_updated": null,
-  "notes": {
-    "triggers": [],
-    "actions": []
-  }
+  "title": "Hedge — Lane A",
+  "source": "pulse/data/hedge/laneA/latest.json",
+  "fields": ["readiness","metrics.max_notional","metrics.var_24h_bps","metrics.slippage_at_size_bps","timestamp"]
 }

--- a/pulse/tiles/hedge/laneB.tile.json
+++ b/pulse/tiles/hedge/laneB.tile.json
@@ -1,15 +1,5 @@
 {
-  "version": "1.0",
-  "lane": "B",
-  "readiness": "unknown",
-  "metrics": {
-    "max_notional": null,
-    "var_24h_bps": null,
-    "slippage_at_size_bps": null
-  },
-  "last_updated": null,
-  "notes": {
-    "triggers": [],
-    "actions": []
-  }
+  "title": "Hedge — Lane B",
+  "source": "pulse/data/hedge/laneB/latest.json",
+  "fields": ["readiness","metrics.max_notional","metrics.var_24h_bps","metrics.slippage_at_size_bps","timestamp"]
 }

--- a/pulse/tiles/index.json
+++ b/pulse/tiles/index.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "env_default": "staging",
+  "tiles": [
+    {"id":"heartbeat","path":"pulse/tiles/heartbeat.tile.json"},
+    {"id":"hedge_laneA","path":"pulse/tiles/hedge/laneA.tile.json"},
+    {"id":"hedge_laneB","path":"pulse/tiles/hedge/laneB.tile.json"},
+    {"id":"pr_activity","path":"pulse/tiles/pr-activity.tile.json"}
+  ]
+}

--- a/pulse/tiles/pr-activity.tile.json
+++ b/pulse/tiles/pr-activity.tile.json
@@ -1,0 +1,7 @@
+{
+  "title": "PR Activity (last 10)",
+  "source": "pulse/api/events/latest.json",
+  "filter": {"component": "PR"},
+  "limit": 10,
+  "fields": ["timestamp","owner","status","summary","pr_number","pr_url"]
+}


### PR DESCRIPTION
## Summary
- define tile specs for heartbeat, hedge lanes, and PR activity plus tiles index
- add workflow to publish tiles and maintain environment pointers
- document tile usage and index retrieval

## Testing
- `jq . pulse/tiles/heartbeat.tile.json`
- `jq . pulse/tiles/hedge/laneA.tile.json`
- `jq . pulse/tiles/hedge/laneB.tile.json`
- `jq . pulse/tiles/pr-activity.tile.json`
- `jq . pulse/tiles/index.json`
- `npm test` *(fails: Could not read package.json)*

[[GENESIS_STATUS component="Pulse" task="wire-pulseboard-tiles-to-structure"]]

------
https://chatgpt.com/codex/tasks/task_e_689abefb679883209d88671c9c5e3db1