### PR TITLE
Pulse: publish genesis-af board + supporting artifacts

### DIFF
--- a/pulse/PULSE/latest.json
+++ b/pulse/PULSE/latest.json
@@ -1,0 +1,12 @@
+{
+  "date": "2025-08-11",
+  "path": "pulse/2025-08-11/run.json",
+  "last_updated": "2025-08-11T17:44:11Z",
+  "last_event": "People/team-update",
+  "annotations": {
+    "hedge": {
+      "laneA": "pulse/tiles/hedge/laneA.tile.json",
+      "laneB": "pulse/tiles/hedge/laneB.tile.json"
+    }
+  }
+}

--- a/pulse/api/events/latest.json
+++ b/pulse/api/events/latest.json
@@ -1,0 +1,135 @@
+[
+  {
+    "component": "People",
+    "task": "team-intros",
+    "status": "info",
+    "owner": "TWOCATS-network",
+    "repo": "twocats-network-status",
+    "workflow": "manual",
+    "run_id": "0",
+    "commit_sha": "",
+    "created_at": "2025-08-11T17:36:06Z",
+    "annotations": {
+      "note": "Genesis core team & lanes",
+      "team": [
+        {
+          "id": "DEV-002",
+          "github_handle": "<unknown>",
+          "role": "Protocol Engineer / Merge Ops",
+          "focus": "Conflict resolution, merge hygiene",
+          "north_star": "No stalled PRs; mainline stable",
+          "threads": [
+            "Merge Ops"
+          ]
+        },
+        {
+          "id": "DEV-003",
+          "github_handle": "<unknown>",
+          "role": "Protocol Developer",
+          "focus": "Core contracts, integrations",
+          "north_star": "Secure, efficient, extensible",
+          "threads": [
+            "Protocol Dev",
+            "CI Alignment"
+          ]
+        },
+        {
+          "id": "DEV-004",
+          "github_handle": "<unknown>",
+          "role": "Research & Pulse Infra",
+          "focus": "Pulse feed + research index",
+          "north_star": "Accurate, up-to-date signals",
+          "threads": [
+            "PulseBridge",
+            "Research Index"
+          ]
+        },
+        {
+          "id": "DEV-005",
+          "github_handle": "<unknown>",
+          "role": "Senior Product / PM",
+          "focus": "Product alignment, Protocol Pack",
+          "north_star": "Specs tight, PRs clean, smooth launch",
+          "threads": [
+            "Mission Control"
+          ]
+        },
+        {
+          "id": "DEV-006",
+          "github_handle": "<unknown>",
+          "role": "Yield Strategy Architect",
+          "focus": "ERC-4626, LP mechanics, stablecoin arb",
+          "north_star": "Green on demand; red actionable",
+          "threads": [
+            "CI Strike Team — Green Gate",
+            "Strategy Dev"
+          ]
+        },
+        {
+          "id": "DEV-007",
+          "github_handle": "<unknown>",
+          "role": "Cross-Chain & RWA Integrator",
+          "focus": "Multi-chain strategies, RWA vaults, NFT gating",
+          "north_star": "Machine-readable Pulse on Pages",
+          "threads": [
+            "Mission Control — PulseBridge",
+            "RWA/Yield Strategy Dev"
+          ]
+        }
+      ],
+      "access": {
+        "team_name": "protocol-devs",
+        "permission": "write",
+        "repos": [
+          "GPDIndex0Bootloader-dev-auth",
+          "twocats-network-status"
+        ]
+      },
+      "rules": {
+        "branch_patterns": [
+          "feat/<slug>",
+          "codex/<slug>"
+        ],
+        "bypass_label": "allow-legacy-branch",
+        "ci_requirements": [
+          "Sentinel v2",
+          "B1/C1 targeted tests"
+        ],
+        "sentinel_version": "v2"
+      }
+    },
+    "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-intros\"]]"
+  }
+  ,{
+    "component": "People",
+    "task": "team-update",
+    "status": "info",
+    "owner": "TWOCATS-network",
+    "repo": "twocats-network-status",
+    "workflow": "manual",
+    "run_id": "0",
+    "commit_sha": "",
+    "created_at": "2025-08-11T17:44:11Z",
+    "annotations": {
+      "note": "Full team status update and current blockers prior to Pulse handoff from Dev-007 to Dev-005.",
+      "team": [
+        { "id": "DEV-003", "role": "Protocol", "focus": "B1 Fate ERC-4626, C1 FLD Add-LP", "north_star": "Green on demand; red means actionable", "threads": ["CI Strike Team"] },
+        { "id": "DEV-004", "role": "Strategies", "focus": "Vault specs & APR/TVL docs", "north_star": "Every vault ships with risk notes and green tests", "threads": ["Genesis Mission Control"] },
+        { "id": "DEV-005", "role": "PulseBridge", "focus": "Pulse feed ops & product tiles", "north_star": "Public machine-readable telemetry, zero ambiguity", "threads": ["Genesis Mission Control"] },
+        { "id": "DEV-006", "role": "CI & Guardrails", "focus": "Compiler pin/mirror/cache, branch policy enforcement", "north_star": "CI stability & enforced guardrails", "threads": ["CI Strike Team"] },
+        { "id": "DEV-007", "role": "Cross-chain Yield & RWA / Pulse setup", "focus": "Initial Pulse bootstrapping & handoff", "north_star": "Fully operational Pulse before handoff", "threads": ["Genesis Mission Control"] }
+      ],
+      "unblockers": [
+        "Fix PR #18 constructor arg mismatch & relax gas bound to ≤130k",
+        "Merge PR #21 (ABI/Gas pipeline) after #18 fix",
+        "Merge Codex tasks for pulse-append.yml + team-intros event",
+        "Create GH_PAGES_TOKEN_PULSE secret + env vars for Pulse repo"
+      ],
+      "urls": [
+        "https://twocats-network.github.io/twocats-network-status/pulse/latest.json",
+        "https://twocats-network.github.io/twocats-network-status/pulse/2025-08-11/run.json"
+      ]
+    },
+    "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-update\"]]"
+  }
+]

--- a/pulse/boards/genesis-af.json
+++ b/pulse/boards/genesis-af.json
@@ -1,0 +1,217 @@
+{
+  "heartbeat": {
+    "date": "2025-08-11",
+    "path": "pulse/2025-08-11/run.json",
+    "last_updated": "2025-08-11T17:44:11Z",
+    "last_event": "People/team-update"
+  },
+  "lanes": {
+    "hedge": {
+      "laneA": {
+        "version": "1.0",
+        "lane": "A",
+        "readiness": "unknown",
+        "metrics": {
+          "max_notional": null,
+          "var_24h_bps": null,
+          "slippage_at_size_bps": null
+        },
+        "last_updated": null,
+        "notes": {
+          "triggers": [],
+          "actions": []
+        }
+      },
+      "laneB": {
+        "version": "1.0",
+        "lane": "B",
+        "readiness": "unknown",
+        "metrics": {
+          "max_notional": null,
+          "var_24h_bps": null,
+          "slippage_at_size_bps": null
+        },
+        "last_updated": null,
+        "notes": {
+          "triggers": [],
+          "actions": []
+        }
+      }
+    }
+  },
+  "events": [
+    {
+      "component": "People",
+      "task": "team-intros",
+      "status": "info",
+      "owner": "TWOCATS-network",
+      "repo": "twocats-network-status",
+      "workflow": "manual",
+      "run_id": "0",
+      "commit_sha": "",
+      "created_at": "2025-08-11T17:36:06Z",
+      "annotations": {
+        "note": "Genesis core team & lanes",
+        "team": [
+          {
+            "id": "DEV-002",
+            "github_handle": "<unknown>",
+            "role": "Protocol Engineer / Merge Ops",
+            "focus": "Conflict resolution, merge hygiene",
+            "north_star": "No stalled PRs; mainline stable",
+            "threads": [
+              "Merge Ops"
+            ]
+          },
+          {
+            "id": "DEV-003",
+            "github_handle": "<unknown>",
+            "role": "Protocol Developer",
+            "focus": "Core contracts, integrations",
+            "north_star": "Secure, efficient, extensible",
+            "threads": [
+              "Protocol Dev",
+              "CI Alignment"
+            ]
+          },
+          {
+            "id": "DEV-004",
+            "github_handle": "<unknown>",
+            "role": "Research & Pulse Infra",
+            "focus": "Pulse feed + research index",
+            "north_star": "Accurate, up-to-date signals",
+            "threads": [
+              "PulseBridge",
+              "Research Index"
+            ]
+          },
+          {
+            "id": "DEV-005",
+            "github_handle": "<unknown>",
+            "role": "Senior Product / PM",
+            "focus": "Product alignment, Protocol Pack",
+            "north_star": "Specs tight, PRs clean, smooth launch",
+            "threads": [
+              "Mission Control"
+            ]
+          },
+          {
+            "id": "DEV-006",
+            "github_handle": "<unknown>",
+            "role": "Yield Strategy Architect",
+            "focus": "ERC-4626, LP mechanics, stablecoin arb",
+            "north_star": "Green on demand; red actionable",
+            "threads": [
+              "CI Strike Team — Green Gate",
+              "Strategy Dev"
+            ]
+          },
+          {
+            "id": "DEV-007",
+            "github_handle": "<unknown>",
+            "role": "Cross-Chain & RWA Integrator",
+            "focus": "Multi-chain strategies, RWA vaults, NFT gating",
+            "north_star": "Machine-readable Pulse on Pages",
+            "threads": [
+              "Mission Control — PulseBridge",
+              "RWA/Yield Strategy Dev"
+            ]
+          }
+        ],
+        "access": {
+          "team_name": "protocol-devs",
+          "permission": "write",
+          "repos": [
+            "GPDIndex0Bootloader-dev-auth",
+            "twocats-network-status"
+          ]
+        },
+        "rules": {
+          "branch_patterns": [
+            "feat/<slug>",
+            "codex/<slug>"
+          ],
+          "bypass_label": "allow-legacy-branch",
+          "ci_requirements": [
+            "Sentinel v2",
+            "B1/C1 targeted tests"
+          ],
+          "sentinel_version": "v2"
+        }
+      },
+      "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-intros\"]]"
+    },
+    {
+      "component": "People",
+      "task": "team-update",
+      "status": "info",
+      "owner": "TWOCATS-network",
+      "repo": "twocats-network-status",
+      "workflow": "manual",
+      "run_id": "0",
+      "commit_sha": "",
+      "created_at": "2025-08-11T17:44:11Z",
+      "annotations": {
+        "note": "Full team status update and current blockers prior to Pulse handoff from Dev-007 to Dev-005.",
+        "team": [
+          {
+            "id": "DEV-003",
+            "role": "Protocol",
+            "focus": "B1 Fate ERC-4626, C1 FLD Add-LP",
+            "north_star": "Green on demand; red means actionable",
+            "threads": [
+              "CI Strike Team"
+            ]
+          },
+          {
+            "id": "DEV-004",
+            "role": "Strategies",
+            "focus": "Vault specs & APR/TVL docs",
+            "north_star": "Every vault ships with risk notes and green tests",
+            "threads": [
+              "Genesis Mission Control"
+            ]
+          },
+          {
+            "id": "DEV-005",
+            "role": "PulseBridge",
+            "focus": "Pulse feed ops & product tiles",
+            "north_star": "Public machine-readable telemetry, zero ambiguity",
+            "threads": [
+              "Genesis Mission Control"
+            ]
+          },
+          {
+            "id": "DEV-006",
+            "role": "CI & Guardrails",
+            "focus": "Compiler pin/mirror/cache, branch policy enforcement",
+            "north_star": "CI stability & enforced guardrails",
+            "threads": [
+              "CI Strike Team"
+            ]
+          },
+          {
+            "id": "DEV-007",
+            "role": "Cross-chain Yield & RWA / Pulse setup",
+            "focus": "Initial Pulse bootstrapping & handoff",
+            "north_star": "Fully operational Pulse before handoff",
+            "threads": [
+              "Genesis Mission Control"
+            ]
+          }
+        ],
+        "unblockers": [
+          "Fix PR #18 constructor arg mismatch & relax gas bound to ≤130k",
+          "Merge PR #21 (ABI/Gas pipeline) after #18 fix",
+          "Merge Codex tasks for pulse-append.yml + team-intros event",
+          "Create GH_PAGES_TOKEN_PULSE secret + env vars for Pulse repo"
+        ],
+        "urls": [
+          "https://twocats-network.github.io/twocats-network-status/pulse/latest.json",
+          "https://twocats-network.github.io/twocats-network-status/pulse/2025-08-11/run.json"
+        ]
+      },
+      "footer_token": "[[GENESIS_STATUS component=\"People\" task=\"team-update\"]]"
+    }
+  ]
+}

--- a/pulse/tiles/index.json
+++ b/pulse/tiles/index.json
@@ -1,0 +1,6 @@
+{
+  "hedge": {
+    "laneA": "hedge/laneA.tile.json",
+    "laneB": "hedge/laneB.tile.json"
+  }
+}


### PR DESCRIPTION
## Summary
- publish aggregated board for genesis-af
- add annotated latest, events api, and tiles index

## Testing
- `jq type pulse/boards/genesis-af.json`
- `jq type pulse/PULSE/latest.json`
- `jq type pulse/api/events/latest.json`
- `jq type pulse/tiles/index.json`


------
https://chatgpt.com/codex/tasks/task_e_689b68a3bd248320af679b19db7cd008